### PR TITLE
support component-specific shorthand rule

### DIFF
--- a/src/__tests__/props-shorthand.test.ts
+++ b/src/__tests__/props-shorthand.test.ts
@@ -34,6 +34,17 @@ test("test", () => {
         options: [{ noShorthand: true }],
       },
       {
+        name: "Grid and Flex props",
+        code: `
+          import { Grid, Flex } from "@chakra-ui/react";
+          
+          <>
+            <Grid gap={2}>Hello</Grid>
+            <Flex gridGap={2} justify="center">Hello</Flex>
+          </>
+        `,
+      },
+      {
         name: "Not chakra element",
         code: `
           import { NotChakra } from "not-chakra";
@@ -70,6 +81,26 @@ test("test", () => {
           import { Box } from "@chakra-ui/react";
             
           <Box margin="2" paddingTop={4}>Hello</Box>
+      `,
+      },
+      {
+        name: "Require Grid and Flex props shorthand",
+        code: `
+          import { Grid, Flex } from "@chakra-ui/react";
+            
+          <>
+            <Grid gridGap={2}>Hello</Grid>
+            <Flex gridGap={2} justifyContent="center">Hello</Flex>
+          </>
+      `,
+        errors: [{ messageId: "enforcesShorthand" }, { messageId: "enforcesShorthand" }],
+        output: `
+          import { Grid, Flex } from "@chakra-ui/react";
+            
+          <>
+            <Grid gap={2}>Hello</Grid>
+            <Flex gridGap={2} justify="center">Hello</Flex>
+          </>
       `,
       },
     ],

--- a/src/lib/getShorthand.ts
+++ b/src/lib/getShorthand.ts
@@ -1,67 +1,88 @@
-const shorthandMap: Record<string, string> = {
-  // Margin
-  margin: "m",
-  marginTop: "mt",
-  marginRight: "mr",
-  marginEnd: "me",
-  marginBottom: "mb",
-  marginLeft: "ml",
-  marginStart: "ms",
-  // Padding
-  padding: "p",
-  paddingTop: "pt",
-  paddingRight: "pr",
-  paddingEnd: "pe",
-  paddingBottom: "pb",
-  paddingLeft: "pl",
-  paddingStart: "ps",
-  //Layout
-  width: "w",
-  height: "h",
-  minWidth: "minW",
-  maxWidth: "maxW",
-  minHeight: "minH",
-  maxHeight: "maxH",
-  display: "d",
-  // Flex
-  alignItems: "align",
-  justifyContent: "justify",
-  flexWrap: "wrap",
-  flexDirection: "flexDir",
-  direction: "flexDir",
-  // Grid
-  gridGap: "gap",
-  gridRowGap: "rowGap",
-  gridColumnGap: "columnGap",
-  gridColumn: "column",
-  gridRow: "row",
-  gridArea: "area",
-  gridAutoFlow: "autoFlow",
-  gridAutoRows: "autoRows",
-  gridAutoColumns: "autoColumns",
-  gridTemplateRows: "templateRows",
-  gridTemplateColumns: "templateColumns",
-  gridTemplateAreas: "templateAreas",
-  // Background
-  background: "bg",
-  backgroundImage: "bgImage",
-  backgroundSize: "bgSize",
-  backgroundPosition: "bgPosition",
-  backgroundRepeat: "bgRepeat",
-  backgroundAttachment: "bgAttachment",
-  backgroundColor: "bgColor",
-  backgroundClip: "bgClip",
+type ShorthandMap = Record<"common" | string, Record<string, string>>;
+
+const shorthandMap: ShorthandMap = {
+  common: {
+    // Margin
+    margin: "m",
+    marginTop: "mt",
+    marginRight: "mr",
+    marginEnd: "me",
+    marginBottom: "mb",
+    marginLeft: "ml",
+    marginStart: "ms",
+    // Padding
+    padding: "p",
+    paddingTop: "pt",
+    paddingRight: "pr",
+    paddingEnd: "pe",
+    paddingBottom: "pb",
+    paddingLeft: "pl",
+    paddingStart: "ps",
+    //Layout
+    width: "w",
+    height: "h",
+    minWidth: "minW",
+    maxWidth: "maxW",
+    minHeight: "minH",
+    maxHeight: "maxH",
+    display: "d",
+    // Flex
+    flexDirection: "flexDir",
+    // Background
+    background: "bg",
+    backgroundImage: "bgImage",
+    backgroundSize: "bgSize",
+    backgroundPosition: "bgPosition",
+    backgroundRepeat: "bgRepeat",
+    backgroundAttachment: "bgAttachment",
+    backgroundColor: "bgColor",
+    backgroundClip: "bgClip",
+  },
+  Flex: {
+    alignItems: "align",
+    justifyContent: "justify",
+    flexWrap: "wrap",
+    flexDirection: "direction",
+    flexDir: "direction",
+  },
+  Grid: {
+    gridGap: "gap",
+    gridRowGap: "rowGap",
+    gridColumnGap: "columnGap",
+    gridColumn: "column",
+    gridRow: "row",
+    gridArea: "area",
+    gridAutoFlow: "autoFlow",
+    gridAutoRows: "autoRows",
+    gridAutoColumns: "autoColumns",
+    gridTemplateRows: "templateRows",
+    gridTemplateColumns: "templateColumns",
+    gridTemplateAreas: "templateAreas",
+  },
 };
 
 const nonShorthandMap = Object.keys(shorthandMap).reduce((ret, key) => {
-  ret[shorthandMap[key]] = key;
+  ret[key] = flipKeyAndValue(shorthandMap[key]);
   return ret;
-}, {} as Record<string, string>);
+}, {} as ShorthandMap);
 
-export function getShorthand(propName: string): string | null {
-  return shorthandMap[propName] || null;
+export function getShorthand(componentName: string, propName: string): string | null {
+  if (shorthandMap[componentName] && shorthandMap[componentName][propName]) {
+    return shorthandMap[componentName][propName];
+  }
+  return shorthandMap["common"][propName] || null;
 }
 
-export function getNonShorthand(propName: string): string | null {
-  return nonShorthandMap[propName] || null;
+export function getNonShorthand(componentName: string, propName: string): string | null {
+  if (nonShorthandMap[componentName] && nonShorthandMap[componentName][propName]) {
+    return nonShorthandMap[componentName][propName];
+  }
+  return nonShorthandMap["common"][propName] || null;
+}
+
+function flipKeyAndValue(record: Record<string, string>): Record<string, string> {
+  return Object.keys(record).reduce((ret, key) => {
+    ret[record[key]] = key;
+    return ret;
+  }, {} as Record<string, string>);
 }

--- a/src/rules/props-shorthand.ts
+++ b/src/rules/props-shorthand.ts
@@ -52,8 +52,12 @@ export const propsShorthandRule: TSESLint.RuleModule<"enforcesShorthand" | "enfo
               return;
             }
 
+            const sourceCode = getSourceCode();
+            const componentName = sourceCode.getText(node.name);
             const propName = attribute.name.name.toString();
-            const newPropName = noShorthand ? getNonShorthand(propName) : getShorthand(propName);
+            const newPropName = noShorthand
+              ? getNonShorthand(componentName, propName)
+              : getShorthand(componentName, propName);
             if (newPropName) {
               report({
                 node: node,


### PR DESCRIPTION
Some property shorthand only works with `Grid` or `Flex`.
ref: https://chakra-ui.com/docs/features/style-props#flexbox