### PR TITLE
Remove ParserService

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![npm](https://img.shields.io/npm/v/eslint-plugin-chakra-ui)](https://www.npmjs.com/package/eslint-plugin-chakra-ui)
 [![license](https://img.shields.io/npm/l/eslint-plugin-chakra-ui)](https://github.com/Monchi/eslint-plugin-chakra-ui/blob/master/LICENSE)
 
-ESLint rules for [Chakra UI](https://chakra-ui.com/) (with TypeScript for now).
+ESLint rules for [Chakra UI](https://chakra-ui.com/).
 
 ## **Requirement**
 
-Currently, this plugin only works with TypeScript, but not with JavaScript, because it depends on `@typescript-eslint/parser`.
+This plugin depends on TypeScript to check whether the component is a Chakra component or not. You need to install `@typescript-eslint/parser` but you can still write vanilla JavaScript.
 
 TypeScript 4.4 or higher is supported.
 
@@ -19,7 +19,7 @@ You'll first need to install [ESLint](https://eslint.org/):
 npm i eslint --save-dev
 ```
 
-Next, install `eslint-plugin-chakra-ui` and `@typescript-eslint/parser`:
+Next, install `eslint-plugin-chakra-ui`, `@typescript-eslint/parser`:
 
 ```sh
 npm install eslint-plugin-chakra-ui @typescript-eslint/parser --save-dev

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -3,9 +3,9 @@ import { test } from "uvu";
 import { propsOrderRule } from "../rules/props-order";
 
 const tester = new TSESLint.RuleTester({
-  parser: require.resolve("@typescript-eslint/parser"),
+  parser: require("espree"),
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2015,
     sourceType: "module",
     ecmaFeatures: {
       jsx: true,

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -48,6 +48,34 @@ test("test", () => {
           <Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
       `,
       },
+      {
+        name: "Default Import",
+        code: `
+          import Chakra from "@chakra-ui/react";
+          
+          <Chakra.Box key={key} as="div"  m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Chakra.Box>
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+            
+          <Chakra.Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Chakra.Box>
+      `,
+      },
+      {
+        name: "Namespace Import",
+        code: `
+          import * from "@chakra-ui/react";
+          
+          <Box key={key} as="div"  m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+            
+          <Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
+      `,
+      },
     ],
   });
 });

--- a/src/lib/isChakraElement.ts
+++ b/src/lib/isChakraElement.ts
@@ -2,21 +2,30 @@ import { AST_NODE_TYPES, JSXOpeningElement } from "@typescript-eslint/types/dist
 
 // To use this function, use updateImportedMap in the import statement.
 export function isChakraElement(node: JSXOpeningElement, importedMap: Map<string, true>): boolean {
+  const nodeName = getNameFromJSX(node);
+  if (nodeName === null) {
+    return false;
+  }
+
+  return importedMap.has(nodeName);
+}
+
+const getNameFromJSX = (node: JSXOpeningElement) => {
   const element = node.name;
 
   switch (element.type) {
     case AST_NODE_TYPES.JSXIdentifier: {
-      return importedMap.has(element.name);
+      return element.name;
     }
     case AST_NODE_TYPES.JSXMemberExpression:
-      return false; // TODO:
+      return element.property.name;
     case AST_NODE_TYPES.JSXNamespacedName:
       // React doesn't support this syntax.
       // See: https://github.com/facebook/jsx/issues/13
-      return false;
+      return null;
     default: {
       const _exhaustiveCheck: never = element;
-      return false;
+      return null;
     }
   }
-}
+};

--- a/src/lib/isHook.ts
+++ b/src/lib/isHook.ts
@@ -1,0 +1,16 @@
+const hooks = [
+  "useBoolean",
+  "useBreakpointValue",
+  "useClipboard",
+  "useConst",
+  "useDisclosure",
+  "useMediaQuery",
+  "useMergeRefs",
+  "useOutsideClick",
+  "usePrefersReducedMotion",
+  "useTheme",
+  "useToken",
+];
+export const isHooks = (name: string) => {
+  return hooks.includes(name);
+};

--- a/src/lib/updateImportedMap.ts
+++ b/src/lib/updateImportedMap.ts
@@ -1,0 +1,30 @@
+import { AST_NODE_TYPES, ImportDeclaration } from "@typescript-eslint/types/dist/ast-spec";
+import { isHooks } from "./isHook";
+
+export function updateImportedMap(importedMap: Map<string, true>, importDeclaration: ImportDeclaration) {
+  const importedList = importDeclaration.specifiers;
+  const from = importDeclaration.source.value;
+  if (from !== "@chakra-ui/react") {
+    return;
+  }
+  for (let i = 0; i < importedList.length; i++) {
+    const imported = importedList[i];
+
+    let maybeComponent;
+    switch (imported.type) {
+      case AST_NODE_TYPES.ImportSpecifier:
+      case AST_NODE_TYPES.ImportDefaultSpecifier:
+        maybeComponent = imported.local.name;
+        break;
+      case AST_NODE_TYPES.ImportNamespaceSpecifier:
+        // TODO:
+        break;
+    }
+
+    // Still 3 kind of possibility: Chakra Component, Chakra Hooks, undefined.
+    if (maybeComponent !== undefined && !isHooks(maybeComponent)) {
+      const compoenent = maybeComponent;
+      importedMap.set(compoenent, true);
+    }
+  }
+}

--- a/src/lib/updateImportedMap.ts
+++ b/src/lib/updateImportedMap.ts
@@ -1,30 +1,32 @@
-import { AST_NODE_TYPES, ImportDeclaration } from "@typescript-eslint/types/dist/ast-spec";
+import { AST_NODE_TYPES, ImportClause, ImportDeclaration } from "@typescript-eslint/types/dist/ast-spec";
 import { isHooks } from "./isHook";
 
 export function updateImportedMap(importedMap: Map<string, true>, importDeclaration: ImportDeclaration) {
   const importedList = importDeclaration.specifiers;
   const from = importDeclaration.source.value;
-  if (from !== "@chakra-ui/react") {
+  const specifiers = ["@chakra-ui/react"];
+  if (!specifiers.includes(from)) {
     return;
   }
-  for (let i = 0; i < importedList.length; i++) {
-    const imported = importedList[i];
 
-    let maybeComponent;
-    switch (imported.type) {
-      case AST_NODE_TYPES.ImportSpecifier:
-      case AST_NODE_TYPES.ImportDefaultSpecifier:
-        maybeComponent = imported.local.name;
-        break;
-      case AST_NODE_TYPES.ImportNamespaceSpecifier:
-        // TODO:
-        break;
-    }
+  importedList.map((imported) => {
+    const maybeComponent = getImportedName(imported);
 
     // Still 3 kind of possibility: Chakra Component, Chakra Hooks, undefined.
     if (maybeComponent !== undefined && !isHooks(maybeComponent)) {
       const compoenent = maybeComponent;
       importedMap.set(compoenent, true);
     }
-  }
+  });
 }
+
+const getImportedName = (imported: ImportClause) => {
+  switch (imported.type) {
+    case AST_NODE_TYPES.ImportSpecifier:
+    case AST_NODE_TYPES.ImportDefaultSpecifier:
+      return imported.local.name;
+    case AST_NODE_TYPES.ImportNamespaceSpecifier:
+      // TODO:
+      return undefined;
+  }
+};

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/experimental-utils";
-import { isChakraElement } from "../lib/isChakraElement";
 import { getPriorityIndex } from "../lib/getPriorityIndex";
+import { isChakraElement } from "../lib/isChakraElement";
+import { updateImportedMap } from "../lib/updateImportedMap";
 
 export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
   meta: {
@@ -21,10 +22,14 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
     if (!parserServices) {
       return {};
     }
+    const importedMap = new Map<string, true>();
 
     return {
+      ImportDeclaration(node) {
+        updateImportedMap(importedMap, node);
+      },
       JSXOpeningElement(node) {
-        if (!isChakraElement(node, parserServices)) {
+        if (!isChakraElement(node, importedMap)) {
           return;
         }
 
@@ -66,6 +71,9 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
             break;
           }
         }
+      },
+      "Program:exit"() {
+        importedMap.clear();
       },
     };
   },


### PR DESCRIPTION
This PR removes ParserService to make it work without TypeScript parser.

I'm not sure how to handle `AST_NODE_TYPES.JSXMemberExpression` and `AST_NODE_TYPES.ImportNamespaceSpecifier`.
The current behavior is to ignore both.