### PR TITLE
Support multi-line sorting

### DIFF
--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -48,6 +48,48 @@ test("test", () => {
           <Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
       `,
       },
+      {
+        name: "Multiple lines must not be concatenated",
+        code: `
+                import { Box } from "@chakra-ui/react";
+
+                <Box
+                  px="2"
+                  as="div"
+                  fontSize="md"
+                  py={2}
+                >
+                  Hello
+                </Box>;
+            `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+                import { Box } from "@chakra-ui/react";
+
+                <Box
+                  as="div"
+                  px="2"
+                  py={2}
+                  fontSize="md"
+                >
+                  Hello
+                </Box>;
+            `,
+      },
+      {
+        name: "Spreading should be sorted",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box {...props} px="2">Hello</Box>
+      `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box px="2" {...props}>Hello</Box>
+      `,
+      },
     ],
   });
 });


### PR DESCRIPTION
This PR enables multi-line sorting.

## Detail

This PR implements the fix function as node swapping.
As an implementation note, if multiple fixes are applied in sequence, the changes should be applied starting from the end of the node so that the node before the update is not affected.

Multi-line sorting could be done with `replaceTextRange`, which old fix function used. But in that way,  the logic would have been complicated with comments and multi-line handling. So, I chose node swapping approach.

Also, a known problem with the PR implementation is that the comment-out position does not move.

From
```javascript
  <Box
    // eslint-disable-next-line no-unused-vars
    _hover={{ unusedVar }}
    as="h1"
  >
    hello
  </Box>
```

To
```
  <Box
    // eslint-disable-next-line no-unused-vars
    as="h1"
    _hover={{ unusedVar }}         // Eslint does warn `unusedVar`!!
  >
    hello
  </Box>
```
