### PR TITLE
Support sorting elements of same priority

### DIFF
--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -32,6 +32,14 @@ test("test", () => {
           <NotChakra m="1" fontSize="md" px="2" py={2}>Hello</NotChakra>
         `,
       },
+      {
+        name: "Spreading should not be sorted",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box py="2" {...props} as="div">Hello</Box>
+      `,
+      },
     ],
     invalid: [
       {
@@ -75,20 +83,6 @@ test("test", () => {
                   Hello
                 </Box>;
             `,
-      },
-      {
-        name: "Spreading should be sorted",
-        code: `
-          import { Box } from "@chakra-ui/react";
-
-          <Box {...props} px="2">Hello</Box>
-      `,
-        errors: [{ messageId: "invalidOrder" }],
-        output: `
-          import { Box } from "@chakra-ui/react";
-
-          <Box {...props} px="2">Hello</Box>
-      `,
       },
       {
         name: "Non chakra props should be sorted in alphabetical order",

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -45,7 +45,7 @@ test("test", () => {
         output: `
           import { Box } from "@chakra-ui/react";
             
-          <Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
+          <Box as="div" key={key} m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
       `,
       },
     ],

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -20,7 +20,7 @@ test("test", () => {
         name: "Sorted style props",
         code: `
           import { Box } from "@chakra-ui/react";
-          
+
           <Box as="div" key={key} m="1" px="2" py={2} fontSize="md" onClick={onClick} {...props}>Hello</Box>
         `,
       },
@@ -47,6 +47,34 @@ test("test", () => {
             
           <Box as="div" key={key} m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
       `,
+      },
+      {
+        name: "Non chakra props should be sorted in alphabetical order",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box onClick={onClick} data-test-id="data-test-id" data-index={1}>Hello</Box>
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box data-index={1} data-test-id="data-test-id" onClick={onClick}>Hello</Box>
+        `,
+      },
+      {
+        name: "Same priority should be sorted in defined order",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box sx={sx} key={key}  textStyle={textStyle} layerStyle={layerStyle} as={as}>Hello</Box>
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box as={as} key={key} sx={sx} layerStyle={layerStyle} textStyle={textStyle}>Hello</Box>
+        `,
       },
     ],
   });

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -201,3 +201,16 @@ export function getPriorityIndex(key: string): number {
   });
   return index === -1 ? Number.MAX_SAFE_INTEGER : index;
 }
+
+export const priorityGroupsLength = priorityGroups.length;
+
+export const getIndexInPriority = (key: string, groupIndex: number): number => {
+  const keys = priorityGroups[groupIndex].keys;
+  if (keys) {
+    const index = keys.indexOf(key);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  }
+
+  // If key doesn't exist, we cann't determine index.
+  return 0;
+};

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -29,9 +29,7 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
           return;
         }
 
-        // const sorted = [...node.attributes].sort((a, b) => {
         const sorted = sortAttributes(node.attributes);
-        // });
 
         const sourceCode = getSourceCode();
         for (const [index, attribute] of node.attributes.entries()) {

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/experimental-utils";
 import { isChakraElement } from "../lib/isChakraElement";
-import { getPriorityIndex } from "../lib/getPriorityIndex";
+import { getIndexInPriority, getPriorityIndex, priorityGroupsLength } from "../lib/getPriorityIndex";
 import { JSXAttribute, JSXSpreadAttribute } from "@typescript-eslint/types/dist/ast-spec";
 
 export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
@@ -109,5 +109,21 @@ const compare = (a: JSXAttribute, b: JSXAttribute) => {
   const aPriority = getPriorityIndex(a.name.name.toString());
   const bPriority = getPriorityIndex(b.name.name.toString());
 
-  return aPriority - bPriority;
+  if (aPriority !== bPriority) {
+    return aPriority - bPriority;
+  }
+
+  // Same Priority. Then compare it.
+  const priority = aPriority;
+  const order = priority <= priorityGroupsLength ? "predefined" : "alphabetical order";
+  switch (order) {
+    case "predefined": {
+      const aIndex = getIndexInPriority(a.name.name.toString(), aPriority);
+      const bIndex = getIndexInPriority(b.name.name.toString(), bPriority);
+
+      return aIndex - bIndex;
+    }
+    case "alphabetical order":
+      return a.name.name < b.name.name ? -1 : 1;
+  }
 };


### PR DESCRIPTION
resolves: #12 

This PR enables sorting in same priority.
![samePrioritySorting](https://user-images.githubusercontent.com/63000297/151659563-61dd22d3-66f8-4706-9630-4e0f76b5e5a8.gif)

### Before:
doesn't sort same priorities. 

### After:
Sort same priorities in defined order.
If the props are from Chakra, they will be sorted by index. If not, they will be sorted alphabetically.




