### PR TITLE
[props-order]: New Sorting Logic

### DIFF
--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -34,7 +34,15 @@ test("test", () => {
         name: "Spreading should not be sorted",
         code: `
           import { Box } from "@chakra-ui/react";
-          <Box py="2" {...props} as="div">Hello</Box>
+          <Box py="2" {...props} as="div">Hello</Box>;
+      `,
+      },
+      {
+        name: "Last priority of style props should be placed before `other props`",
+        // priorityGroups.at(-1).at(-1) is outline;
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box outline='outline' aaaa>Hello</Box>;
       `,
       },
     ],
@@ -214,10 +222,10 @@ test("test", () => {
         code: `
           import { Box } from "@chakra-ui/react";
           <Box
-            className={className}
             key={key}
-            ref={ref}
+            className={className}
             dangerouslySetInnerHtml={dangerouslySetInnerHtml}
+            ref={ref}
           >
             Hello
           </Box>;
@@ -227,9 +235,35 @@ test("test", () => {
           import { Box } from "@chakra-ui/react";
           <Box
             className={className}
-            dangerouslySetInnerHtml={dangerouslySetInnerHtml}
             key={key}
             ref={ref}
+            dangerouslySetInnerHtml={dangerouslySetInnerHtml}
+          >
+            Hello
+          </Box>;
+        `,
+      },
+      {
+        name: "ReservedPriority should be sorted",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            aria-label="aria-label"
+            // variant={variant}
+            className={className}
+            p={p}
+          >
+            Hello
+          </Box>;
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            // variant={variant}
+            p={p}
+            aria-label="aria-label"
           >
             Hello
           </Box>;

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -109,19 +109,19 @@ test("test", () => {
           animation="animation"
           appearance="appearance"
           transform="transform"
-          transformOrigin="transformOrigin"
           visibility="visibility"
+          resize="resize"
           whiteSpace="whiteSpace"
-          userSelect="userSelect"
           pointerEvents="pointerEvents"
           wordBreak="wordBreak"
           overflowWrap="overflowWrap"
           textOverflow="textOverflow"
           boxSizing="boxSizing"
+          transformOrigin="transformOrigin"
           cursor="cursor"
-          resize="resize"
           transition="transition"
           objectFit="objectFit"
+          userSelect="userSelect"
           objectPosition="objectPosition"
           float="float"
           outline="outline"
@@ -150,7 +150,7 @@ test("test", () => {
           transition="transition"
           objectFit="objectFit"
           objectPosition="objectPosition"
-          stroke="stroke"
+          float="float"
           outline="outline"
         >
           Same priority should be sorted in defined order
@@ -204,6 +204,32 @@ test("test", () => {
             _hover={_hover}
             animation={animation}
             data-test-id={dataTestId}
+          >
+            Hello
+          </Box>;
+        `,
+      },
+      {
+        name: "ReservedPriority should be sorted",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            key={key}
+            ref={ref}
+            dangerouslySetInnerHtml={dangerouslySetInnerHtml}
+          >
+            Hello
+          </Box>;
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            dangerouslySetInnerHtml={dangerouslySetInnerHtml}
+            key={key}
+            ref={ref}
           >
             Hello
           </Box>;

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -28,7 +28,7 @@ test("test", () => {
         name: "Not chakra element",
         code: `
           import { NotChakra } from "not-chakra";
-          
+
           <NotChakra m="1" fontSize="md" px="2" py={2}>Hello</NotChakra>
         `,
       },
@@ -46,13 +46,11 @@ test("test", () => {
         name: "Not sorted",
         code: `
           import { Box } from "@chakra-ui/react";
-
           <Box px="2" as="div" onClick={onClick} m="1" key={key} {...props} fontSize="md" py={2}>Hello</Box>
       `,
         errors: [{ messageId: "invalidOrder" }],
         output: `
           import { Box } from "@chakra-ui/react";
-
           <Box as="div" key={key} m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
       `,
       },
@@ -60,7 +58,6 @@ test("test", () => {
         name: "Multiple lines must not be concatenated",
         code: `
                 import { Box } from "@chakra-ui/react";
-
                 <Box
                   px="2"
                   as="div"
@@ -73,7 +70,6 @@ test("test", () => {
         errors: [{ messageId: "invalidOrder" }],
         output: `
                 import { Box } from "@chakra-ui/react";
-
                 <Box
                   as="div"
                   px="2"
@@ -88,13 +84,11 @@ test("test", () => {
         name: "Non chakra props should be sorted in alphabetical order",
         code: `
           import { Box } from "@chakra-ui/react";
-
           <Box onClick={onClick} data-test-id="data-test-id" data-index={1}>Hello</Box>
         `,
         errors: [{ messageId: "invalidOrder" }],
         output: `
           import { Box } from "@chakra-ui/react";
-
           <Box data-index={1} data-test-id="data-test-id" onClick={onClick}>Hello</Box>
         `,
       },
@@ -102,14 +96,64 @@ test("test", () => {
         name: "Same priority should be sorted in defined order",
         code: `
           import { Box } from "@chakra-ui/react";
-
           <Box sx={sx} key={key} textStyle={textStyle} layerStyle={layerStyle} as={as}>Hello</Box>
         `,
         errors: [{ messageId: "invalidOrder" }],
         output: `
           import { Box } from "@chakra-ui/react";
-
           <Box as={as} key={key} sx={sx} layerStyle={layerStyle} textStyle={textStyle}>Hello</Box>
+        `,
+      },
+      {
+        name: "Different priorities should be sorted by priorities",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            as={as}
+            _hover={_hover}
+            position={position}
+            shadow={shadow}
+            animation={animation}
+            m={m}
+            data-test-id={dataTestId}
+            flex={flex}
+            color={color}
+            fontFamily={fontFamily}
+            bg={bg}
+            w={w}
+            h={h}
+            display={display}
+            borderRadius={borderRadius}
+            p={p}
+            gridGap={gridGap}
+          >
+            Hello
+          </Box>;
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            as={as}
+            position={position}
+            flex={flex}
+            gridGap={gridGap}
+            display={display}
+            w={w}
+            h={h}
+            m={m}
+            p={p}
+            color={color}
+            fontFamily={fontFamily}
+            bg={bg}
+            borderRadius={borderRadius}
+            shadow={shadow}
+            _hover={_hover}
+            animation={animation}
+            data-test-id={dataTestId}
+          >
+            Hello
+          </Box>;
         `,
       },
     ],

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -269,6 +269,98 @@ test("test", () => {
           </Box>;
         `,
       },
+      {
+        name: "if keys are not reservedFirstProps, they should be sorted in alphabetical order",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            key={key}
+            ref={ref}
+            aria-label="aria-label"
+          >
+            Hello
+          </Box>;
+        `,
+        options: [
+          {
+            firstProps: [],
+          },
+        ],
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            aria-label="aria-label"
+            className={className}
+            key={key}
+            ref={ref}
+          >
+            Hello
+          </Box>;
+        `,
+      },
+      {
+        name: "if lastProps is specified, that must be the last.",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            onClick={onClick}
+            bg={bg}
+            aria-label="aria-label"
+          >
+            onClick should be the last
+          </Box>;
+        `,
+        options: [
+          {
+            lastProps: ["onClick", "aria-label"],
+          },
+        ],
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            className={className}
+            bg={bg}
+            onClick={onClick}
+            aria-label="aria-label"
+          >
+            onClick should be the last
+          </Box>;
+        `,
+      },
+      {
+        name: "if same property is set for both firstProps and lastProps, that of lastProps will be ignored.",
+        code: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            onClick={onClick}
+            bg={bg}
+            aria-label="aria-label"
+          >
+          If the same key is given different priorities in option, ignore all but the first.
+          </Box>;
+        `,
+        options: [
+          {
+            lastProps: ["onClick", "aria-label"],
+            firstProps: ["onClick", "aria-label"],
+          },
+        ],
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+          import { Box } from "@chakra-ui/react";
+          <Box
+            onClick={onClick}
+            aria-label="aria-label"
+            bg={bg}
+          >
+          If the same key is given different priorities in option, ignore all but the first.
+          </Box>;
+        `,
+      },
     ],
   });
 });

--- a/src/__tests__/props-order.test.ts
+++ b/src/__tests__/props-order.test.ts
@@ -20,15 +20,13 @@ test("test", () => {
         name: "Sorted style props",
         code: `
           import { Box } from "@chakra-ui/react";
-
-          <Box as="div" key={key} m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
+          <Box key={key} as="div" m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
         `,
       },
       {
         name: "Not chakra element",
         code: `
           import { NotChakra } from "not-chakra";
-
           <NotChakra m="1" fontSize="md" px="2" py={2}>Hello</NotChakra>
         `,
       },
@@ -36,7 +34,6 @@ test("test", () => {
         name: "Spreading should not be sorted",
         code: `
           import { Box } from "@chakra-ui/react";
-
           <Box py="2" {...props} as="div">Hello</Box>
       `,
       },
@@ -51,7 +48,7 @@ test("test", () => {
         errors: [{ messageId: "invalidOrder" }],
         output: `
           import { Box } from "@chakra-ui/react";
-          <Box as="div" key={key} m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
+          <Box key={key} as="div" m="1" px="2" onClick={onClick} {...props} py={2} fontSize="md">Hello</Box>
       `,
       },
       {
@@ -96,12 +93,68 @@ test("test", () => {
         name: "Same priority should be sorted in defined order",
         code: `
           import { Box } from "@chakra-ui/react";
-          <Box sx={sx} key={key} textStyle={textStyle} layerStyle={layerStyle} as={as}>Hello</Box>
+          <Box sx={sx} textStyle={textStyle} layerStyle={layerStyle} as={as}>Hello</Box>
         `,
         errors: [{ messageId: "invalidOrder" }],
         output: `
           import { Box } from "@chakra-ui/react";
-          <Box as={as} key={key} sx={sx} layerStyle={layerStyle} textStyle={textStyle}>Hello</Box>
+          <Box as={as} sx={sx} layerStyle={layerStyle} textStyle={textStyle}>Hello</Box>
+        `,
+      },
+      {
+        name: "Same priority should be sorted in defined order",
+        code: `
+        import { Box } from "@chakra-ui/react";
+        <Box
+          animation="animation"
+          appearance="appearance"
+          transform="transform"
+          transformOrigin="transformOrigin"
+          visibility="visibility"
+          whiteSpace="whiteSpace"
+          userSelect="userSelect"
+          pointerEvents="pointerEvents"
+          wordBreak="wordBreak"
+          overflowWrap="overflowWrap"
+          textOverflow="textOverflow"
+          boxSizing="boxSizing"
+          cursor="cursor"
+          resize="resize"
+          transition="transition"
+          objectFit="objectFit"
+          objectPosition="objectPosition"
+          float="float"
+          outline="outline"
+        >
+          Same priority should be sorted in defined order
+        </Box>;
+        `,
+        errors: [{ messageId: "invalidOrder" }],
+        output: `
+        import { Box } from "@chakra-ui/react";
+        <Box
+          animation="animation"
+          appearance="appearance"
+          transform="transform"
+          transformOrigin="transformOrigin"
+          visibility="visibility"
+          whiteSpace="whiteSpace"
+          userSelect="userSelect"
+          pointerEvents="pointerEvents"
+          wordBreak="wordBreak"
+          overflowWrap="overflowWrap"
+          textOverflow="textOverflow"
+          boxSizing="boxSizing"
+          cursor="cursor"
+          resize="resize"
+          transition="transition"
+          objectFit="objectFit"
+          objectPosition="objectPosition"
+          stroke="stroke"
+          outline="outline"
+        >
+          Same priority should be sorted in defined order
+        </Box>;
         `,
       },
       {

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -358,7 +358,7 @@ const priorityGroups: readonly PriorityGroup[] = [
 ];
 
 export function getPriority(key: string, config: Config): number {
-  // getPriority returns a number. The smaller is the heigher priority.
+  // getPriority returns a number. The smaller is the higher priority.
   // Properties will have their "group priority", determined by which group property belongs, and "inGroup priority", determined by index in that group.
   const { firstProps, lastProps, componentSpecificProps } = config;
   const indexInFirstProps = firstProps.indexOf(key);

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -403,7 +403,7 @@ const calcPriorityFromIndex = (index: Index, config: Config) => {
   // They will be treated as "other Props".
 
   // Currently, the priority is determined from the index of the array.
-  // We assume that the length of each array is atmost 100.
+  // We assume that the length of each array is at most 100.
   // When changing the specification, be sure to check that the stylePropsPriority range does not overlap with others.
   // Now it's range is [200, 10200]. 10200 is 100 * 100 + 200.
 

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -449,10 +449,6 @@ const calcPriorityFromIndex = (index: Index, config: Config) => {
       const InGroupPriority = index.value;
       return groupPriority + InGroupPriority;
     }
-    default: {
-      const _x: never = index;
-      return -1;
-    }
   }
 };
 

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -1,12 +1,46 @@
+const priority = {
+  // System
+  System: 0,
+
+  // Positioning
+  Position: 10,
+
+  // Box Model
+  Flexbox: 20,
+  "Grid Layout": 21,
+  Layout: 22,
+  Width: 23,
+  Height: 24,
+  Margin: 25,
+  Padding: 26,
+
+  // Typography
+  Color: 30,
+  Typography: 31,
+
+  // Visual
+  Background: 40,
+  Border: 41,
+  "Border Radius": 42,
+
+  // Misc
+  Shadow: 50,
+  Pseudo: 51,
+  "Other Style Props": 52,
+} as const;
+type Priority = typeof priority;
+
 type PriorityGroup = {
   name: string;
   keys: readonly string[];
+  priority: Priority[keyof Priority];
 };
 
 const priorityGroups: readonly PriorityGroup[] = [
   {
     name: "System",
     keys: ["as", "key", "sx", "layerStyle", "textStyle"],
+    priority: priority["System"],
   },
   {
     name: "Margin",
@@ -28,6 +62,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "mx",
       "my",
     ],
+    priority: priority["Margin"],
   },
   {
     name: "Padding",
@@ -49,10 +84,12 @@ const priorityGroups: readonly PriorityGroup[] = [
       "px",
       "py",
     ],
+    priority: priority["Padding"],
   },
   {
     name: "Color",
     keys: ["color", "textColor", "fill", "stroke"],
+    priority: priority["Color"],
   },
   {
     name: "Typography",
@@ -67,18 +104,22 @@ const priorityGroups: readonly PriorityGroup[] = [
       "textTransform",
       "textDecoration",
     ],
+    priority: priority["Typography"],
   },
   {
     name: "Width",
     keys: ["w", "width", "minW", "minWidth", "maxW", "maxWidth"],
+    priority: priority["Width"],
   },
   {
     name: "Height",
     keys: ["h", "height", "minH", "minHeight", "maxH", "maxHeight"],
+    priority: priority["Height"],
   },
   {
     name: "Layout",
     keys: ["d", "display", "boxSize", "verticalAlign", "overflow", "overflowX", "overflowY"],
+    priority: priority["Layout"],
   },
   {
     name: "Flexbox",
@@ -102,6 +143,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "alignSelf",
       "order",
     ],
+    priority: priority["Flexbox"],
   },
   {
     name: "Grid Layout",
@@ -131,6 +173,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "gridTemplateAreas",
       "templateAreas",
     ],
+    priority: priority["Grid Layout"],
   },
   {
     name: "Background",
@@ -152,6 +195,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "backgroundClip",
       "opacity",
     ],
+    priority: priority["Background"],
   },
   {
     name: "Border",
@@ -187,6 +231,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "borderX",
       "borderY",
     ],
+    priority: priority["Border"],
   },
   {
     name: "Border Radius",
@@ -207,14 +252,17 @@ const priorityGroups: readonly PriorityGroup[] = [
       "borderLeftRadius",
       "borderStartRadius",
     ],
+    priority: priority["Border Radius"],
   },
   {
     name: "Position",
     keys: ["pos", "position", "zIndex", "top", "right", "bottom", "left"],
+    priority: priority["Position"],
   },
   {
     name: "Shadow",
     keys: ["textShadow", "shadow", "boxShadow"],
+    priority: priority["Shadow"],
   },
   {
     name: "Pseudo",
@@ -277,6 +325,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "_dark",
       "_light",
     ],
+    priority: priority["Pseudo"],
   },
   {
     name: "Other Style Props",
@@ -303,25 +352,21 @@ const priorityGroups: readonly PriorityGroup[] = [
       "stroke",
       "outline",
     ],
+    priority: priority["Other Style Props"],
   },
 ];
 
-export function getPriorityIndex(key: string): number {
+export function getPriority(key: string): number {
   const index = priorityGroups.findIndex((group) => {
     return group.keys.includes(key);
   });
-  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  return index === -1 ? Number.MAX_SAFE_INTEGER : priorityGroups[index].priority;
 }
 
 export const priorityGroupsLength = priorityGroups.length;
 
 export const getIndexInPriority = (key: string, groupIndex: number): number => {
   const keys = priorityGroups[groupIndex].keys;
-  if (keys) {
-    const index = keys.indexOf(key);
-    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
-  }
-
-  // If key doesn't exist, we cann't determine index.
-  return 0;
+  const index = keys.indexOf(key);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
 };

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -1,6 +1,7 @@
 const priority = {
   // System
   System: 0,
+  ComponentSpecificProps: 1,
 
   // Positioning
   Position: 10,
@@ -39,8 +40,13 @@ type PriorityGroup = {
 const priorityGroups: readonly PriorityGroup[] = [
   {
     name: "System",
-    keys: ["as", "key", "sx", "layerStyle", "textStyle"],
+    keys: ["as", "sx", "layerStyle", "textStyle"],
     priority: priority["System"],
+  },
+  {
+    name: "ComponentSpecificProps",
+    keys: [], // TODO
+    priority: priority["ComponentSpecificProps"],
   },
   {
     name: "Margin",
@@ -334,7 +340,7 @@ const priorityGroups: readonly PriorityGroup[] = [
       "appearance",
       "transform",
       "transformOrigin",
-      "visiblity",
+      "visibility",
       "whiteSpace",
       "userSelect",
       "pointerEvents",
@@ -348,19 +354,34 @@ const priorityGroups: readonly PriorityGroup[] = [
       "objectFit",
       "objectPosition",
       "float",
-      "fill",
-      "stroke",
       "outline",
     ],
     priority: priority["Other Style Props"],
   },
 ];
 
-export function getPriority(key: string): number {
+const FIRST_PROPS = -1;
+const OTHER_PROPS = 1000;
+const LAST_PROPS = Number.MAX_SAFE_INTEGER;
+
+export function getPriority(key: string, config: { firstProps: string[]; lastProps: string[] }): number {
+  const { firstProps, lastProps } = config;
+
+  if (firstProps.includes(key)) {
+    return FIRST_PROPS;
+  }
+  if (lastProps.includes(key)) {
+    return LAST_PROPS;
+  }
+
   const index = priorityGroups.findIndex((group) => {
     return group.keys.includes(key);
   });
-  return index === -1 ? Number.MAX_SAFE_INTEGER : priorityGroups[index].priority;
+  if (index !== -1) {
+    return priorityGroups[index].priority;
+  }
+
+  return OTHER_PROPS;
 }
 
 export const priorityGroupsLength = priorityGroups.length;

--- a/src/lib/getPriorityIndex.ts
+++ b/src/lib/getPriorityIndex.ts
@@ -412,10 +412,10 @@ const calcPriorityFromIndex = (index: Index, config: Config) => {
   const isComponentSpecBeforeStyle = config.isCompPropsBeforeStyleProps;
   const basePriorities = {
     firstProps: 0,
-    styleProps: 200,
-    componentSpecificProps: isComponentSpecBeforeStyle ? 100 : 10 * 5,
-    otherProps: 10 ** 6,
-    lastProps: 10 ** 6 + 1,
+    styleProps: 20000,
+    componentSpecificProps: isComponentSpecBeforeStyle ? 10000 : 30000,
+    otherProps: 40000,
+    lastProps: 50000,
   };
 
   switch (index.type) {
@@ -431,7 +431,7 @@ const calcPriorityFromIndex = (index: Index, config: Config) => {
       const groupPriority = priorityGroups[groupIndex].priority;
       const InGroupPriority = keyIndex;
 
-      // By useing the following formula, we can assign a unique priority to each props of style props.
+      // By using the following formula, we can assign a unique priority to each props of style props.
       // Justification: Since priorityGroups[**].length is less than 100, there is no duplicate.
       return basePriority + groupPriority * 100 + InGroupPriority;
     }

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -105,9 +105,18 @@ const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[]) => {
   return sorted;
 };
 
+// Temporarily placed here.
+const option: { firstProps?: string[]; lastProps?: string[] } = {};
+const defaultFirstProps = ["className", "key", "ref", "dangerouslySetInnerHtml"];
+const defaultLastProps: string[] = [];
+const config = {
+  firstProps: option.firstProps ? option.firstProps : defaultFirstProps,
+  lastProps: option.lastProps ? option.lastProps : defaultLastProps,
+};
+
 const compare = (a: JSXAttribute, b: JSXAttribute) => {
-  const aPriority = getPriority(a.name.name.toString());
-  const bPriority = getPriority(b.name.name.toString());
+  const aPriority = getPriority(a.name.name.toString(), config);
+  const bPriority = getPriority(b.name.name.toString(), config);
 
   if (aPriority !== bPriority) {
     return aPriority - bPriority;
@@ -116,11 +125,11 @@ const compare = (a: JSXAttribute, b: JSXAttribute) => {
   // Same Priority. Then compare it.
   const priority = aPriority;
   const order = priority <= priorityGroupsLength ? "predefined" : "alphabetical order";
+
   switch (order) {
     case "predefined": {
       const aIndex = getIndexInPriority(a.name.name.toString(), aPriority);
       const bIndex = getIndexInPriority(b.name.name.toString(), bPriority);
-
       return aIndex - bIndex;
     }
     case "alphabetical order":

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -123,9 +123,9 @@ const compare = (a: JSXAttribute, b: JSXAttribute) => {
   }
 
   // Same Priority. Then compare it.
-  const order = "alphabetical order";
+  const ordering = "alphabetical order";
 
-  switch (order) {
+  switch (ordering) {
     case "alphabetical order":
       return a.name.name < b.name.name ? -1 : 1;
   }

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/utils";
 import { isChakraElement } from "../lib/isChakraElement";
-import { getIndexInPriority, getPriority, priorityGroupsLength } from "../lib/getPriorityIndex";
+import { getPriority } from "../lib/getPriorityIndex";
 import { JSXAttribute, JSXSpreadAttribute } from "@typescript-eslint/types/dist/ast-spec";
 
 export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
@@ -123,15 +123,9 @@ const compare = (a: JSXAttribute, b: JSXAttribute) => {
   }
 
   // Same Priority. Then compare it.
-  const priority = aPriority;
-  const order = priority < priorityGroupsLength ? "predefined" : "alphabetical order";
+  const order = "alphabetical order";
 
   switch (order) {
-    case "predefined": {
-      const aIndex = getIndexInPriority(a.name.name.toString(), aPriority);
-      const bIndex = getIndexInPriority(b.name.name.toString(), bPriority);
-      return aIndex - bIndex;
-    }
     case "alphabetical order":
       return a.name.name < b.name.name ? -1 : 1;
   }

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -124,7 +124,7 @@ const compare = (a: JSXAttribute, b: JSXAttribute) => {
 
   // Same Priority. Then compare it.
   const priority = aPriority;
-  const order = priority <= priorityGroupsLength ? "predefined" : "alphabetical order";
+  const order = priority < priorityGroupsLength ? "predefined" : "alphabetical order";
 
   switch (order) {
     case "predefined": {

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/utils";
 import { isChakraElement } from "../lib/isChakraElement";
-import { getIndexInPriority, getPriorityIndex, priorityGroupsLength } from "../lib/getPriorityIndex";
+import { getIndexInPriority, getPriority, priorityGroupsLength } from "../lib/getPriorityIndex";
 import { JSXAttribute, JSXSpreadAttribute } from "@typescript-eslint/types/dist/ast-spec";
 
 export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", []> = {
@@ -106,8 +106,8 @@ const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[]) => {
 };
 
 const compare = (a: JSXAttribute, b: JSXAttribute) => {
-  const aPriority = getPriorityIndex(a.name.name.toString());
-  const bPriority = getPriorityIndex(b.name.name.toString());
+  const aPriority = getPriority(a.name.name.toString());
+  const bPriority = getPriority(b.name.name.toString());
 
   if (aPriority !== bPriority) {
     return aPriority - bPriority;

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -7,7 +7,7 @@ type Options = [
   {
     firstProps?: string[];
     lastProps?: string[];
-    compPropsBeforeStyleProps?: boolean;
+    displayCompPropsBeforeStyleProps?: boolean;
   }
 ];
 
@@ -19,6 +19,7 @@ export type Config = {
 };
 const defaultFirstProps = ["className", "key", "ref", "dangerouslySetInnerHtml"];
 const defaultLastProps: string[] = [];
+// const defaultIsCompPropsBeforeStyleProps = false;
 
 export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
   meta: {
@@ -45,7 +46,7 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
             items: { type: "string", minLength: 0 },
             uniqueItems: true,
           },
-          compPropsBeforeStyleProps: {
+          displayCompPropsBeforeStyleProps: {
             type: "boolean",
             default: false,
           },
@@ -70,7 +71,7 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
         const config: Config = {
           firstProps: option?.firstProps ? option?.firstProps : defaultFirstProps,
           lastProps: option?.lastProps ? option?.lastProps : defaultLastProps,
-          isCompPropsBeforeStyleProps: true,
+          isCompPropsBeforeStyleProps: true, // options?.defaultIsCompPropsBeforeStyleProps ? ~ : defaultLastProps
           componentSpecificProps: undefined, // not supported yet
         };
         const sorted = sortAttributes(node.attributes, config);

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -71,7 +71,7 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
         const config: Config = {
           firstProps: option?.firstProps ? option?.firstProps : defaultFirstProps,
           lastProps: option?.lastProps ? option?.lastProps : defaultLastProps,
-          isCompPropsBeforeStyleProps: true, // options?.defaultIsCompPropsBeforeStyleProps ? ~ : defaultLastProps
+          isCompPropsBeforeStyleProps: true, // options?.displayCompPropsBeforeStyleProps ? ~ : defaultIsCompPropsBeforeStyleProps
           componentSpecificProps: undefined, // not supported yet
         };
         const sorted = sortAttributes(node.attributes, config);


### PR DESCRIPTION
This PR makes the order of props in Chakra UI more meaningful and customizable.

## Groups of `Style props`
1. Reserved first `*`
2. Component-specific props
3. Style props
    1. System
    2. Positioning
    3. Box Model
    4. Typography
    5. Visual
    6. misc.
4. Other props
5. Reserved last `*`
* `*` indicates it can be customizable via options.
* discussion: #15 


## Options
We have 3 options now, but `displayCompPropsBeforeStyleProps` has no effect yet.
Available options:
```
firstProps: {
  type: "array",
  items: { type: "string", minLength: 0 },
  uniqueItems: true,
},
lastProps: {
  type: "array",
  items: { type: "string", minLength: 0 },
  uniqueItems: true,
},
displayCompPropsBeforeStyleProps: {
  type: "boolean",
  default: false,
},
```

Example:
```
// .eslintrc.js
rules: {
    'chakra-ui/props-order': [
        'warn',
        {
            lastProps: ['onClick'], // Note: This is not an addition, but a replacement.
            firstProps: ['onTouch'], // Note: This is not an addition, but a replacement.
            displayCompPropsBeforeStyleProps:['true']
        },
    ],
}
```
`Component-specific props` are empty because it has not been decided how to implement them.