### PR TITLE
Fix unhandled JSXSpreadAttributes 

### DIFF
--- a/src/__tests__/props-shorthand.test.ts
+++ b/src/__tests__/props-shorthand.test.ts
@@ -103,6 +103,26 @@ test("test", () => {
           </>
       `,
       },
+      {
+        name: "Support JSXSpreadAttribute",
+        code: `
+          import { Grid, Flex } from "@chakra-ui/react";
+            
+          <>
+            <Grid {...{w:2}} gridGap={2}>Hello</Grid>
+            <Flex {...{w:2}} gridGap={2} justifyContent="center">Hello</Flex>
+          </>
+      `,
+        errors: [{ messageId: "enforcesShorthand" }, { messageId: "enforcesShorthand" }],
+        output: `
+          import { Grid, Flex } from "@chakra-ui/react";
+            
+          <>
+            <Grid {...{w:2}} gap={2}>Hello</Grid>
+            <Flex {...{w:2}} gridGap={2} justify="center">Hello</Flex>
+          </>
+      `,
+      },
     ],
   });
 });

--- a/src/rules/props-shorthand.ts
+++ b/src/rules/props-shorthand.ts
@@ -49,7 +49,7 @@ export const propsShorthandRule: TSESLint.RuleModule<"enforcesShorthand" | "enfo
 
           for (const attribute of node.attributes) {
             if (attribute.type !== AST_NODE_TYPES.JSXAttribute) {
-              return;
+              continue;
             }
 
             const sourceCode = getSourceCode();


### PR DESCRIPTION
This PR modifies `props-shorehand` rule to lint nodes that contain JSXSpreadAttributes.