### PR TITLE
Support Position's shorthand props

### DIFF
--- a/src/lib/getShorthand.ts
+++ b/src/lib/getShorthand.ts
@@ -37,6 +37,8 @@ const shorthandMap: ShorthandMap = {
     backgroundAttachment: "bgAttachment",
     backgroundColor: "bgColor",
     backgroundClip: "bgClip",
+    // Position
+    position: "pos",
   },
   Flex: {
     alignItems: "align",


### PR DESCRIPTION
Hey, thanks for the nice works.

I have added this plugin to my project and found that the `position` is not converted to `pos`.
https://chakra-ui.com/docs/features/style-props#position

And I have tried to fix it and would appreciate a review.