### PR TITLE
Upgrade typescript-eslint monorepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^5.10.1"
+        "@typescript-eslint/utils": "^5.15.0"
       },
       "devDependencies": {
         "@swc-node/register": "^1.4.2",
         "@swc/cli": "^0.1.55",
         "@swc/core": "^1.2.127",
         "@types/node": "^17.0.8",
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "@typescript-eslint/types": "^5.10.0",
+        "@typescript-eslint/eslint-plugin": "^5.15.0",
+        "@typescript-eslint/parser": "^5.15.0",
+        "@typescript-eslint/types": "^5.15.0",
         "eslint": "^8.0.1",
         "eslint-plugin-eslint-plugin": "^4.0.1",
         "eslint-plugin-unused-imports": "^2.0.0",
@@ -447,14 +447,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-      "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
+      "integrity": "sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/type-utils": "5.10.0",
-        "@typescript-eslint/utils": "5.10.0",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/type-utils": "5.15.0",
+        "@typescript-eslint/utils": "5.15.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -479,52 +479,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-      "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/typescript-estree": "5.10.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -535,14 +489,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-      "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz",
+      "integrity": "sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/typescript-estree": "5.10.0",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/typescript-estree": "5.15.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -562,13 +516,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-      "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
+      "integrity": "sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==",
       "dependencies": {
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/visitor-keys": "5.10.0"
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/visitor-keys": "5.15.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -579,12 +532,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-      "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
+      "integrity": "sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.10.0",
+        "@typescript-eslint/utils": "5.15.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -604,57 +557,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-      "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/typescript-estree": "5.10.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-      "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz",
+      "integrity": "sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -664,13 +570,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-      "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
+      "integrity": "sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/visitor-keys": "5.10.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/visitor-keys": "5.15.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -691,14 +596,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.15.0.tgz",
+      "integrity": "sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/typescript-estree": "5.15.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -711,76 +616,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
@@ -804,12 +639,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-      "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
+      "integrity": "sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==",
       "dependencies": {
-        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/types": "5.15.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3191,14 +3025,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-      "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz",
+      "integrity": "sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/type-utils": "5.10.0",
-        "@typescript-eslint/utils": "5.10.0",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/type-utils": "5.15.0",
+        "@typescript-eslint/utils": "5.15.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -3207,36 +3041,6 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "@typescript-eslint/utils": {
-          "version": "5.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-          "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.10.0",
-            "@typescript-eslint/types": "5.10.0",
-            "@typescript-eslint/typescript-estree": "5.10.0",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        },
         "ignore": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -3246,84 +3050,49 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
-      "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz",
+      "integrity": "sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.0",
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/typescript-estree": "5.10.0",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/typescript-estree": "5.15.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
-      "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz",
+      "integrity": "sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==",
       "requires": {
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/visitor-keys": "5.10.0"
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/visitor-keys": "5.15.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
-      "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz",
+      "integrity": "sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.10.0",
+        "@typescript-eslint/utils": "5.15.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/utils": {
-          "version": "5.10.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
-          "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.10.0",
-            "@typescript-eslint/types": "5.10.0",
-            "@typescript-eslint/typescript-estree": "5.10.0",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
-      "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
-      "dev": true
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz",
+      "integrity": "sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
-      "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz",
+      "integrity": "sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==",
       "requires": {
-        "@typescript-eslint/types": "5.10.0",
-        "@typescript-eslint/visitor-keys": "5.10.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/visitor-keys": "5.15.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -3332,55 +3101,18 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.15.0.tgz",
+      "integrity": "sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==",
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.15.0",
+        "@typescript-eslint/types": "5.15.0",
+        "@typescript-eslint/typescript-estree": "5.15.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
       "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-          "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
-          "requires": {
-            "@typescript-eslint/types": "5.10.1",
-            "@typescript-eslint/visitor-keys": "5.10.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-          "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q=="
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-          "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
-          "requires": {
-            "@typescript-eslint/types": "5.10.1",
-            "@typescript-eslint/visitor-keys": "5.10.1",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.10.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-          "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
-          "requires": {
-            "@typescript-eslint/types": "5.10.1",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
         "eslint-scope": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3398,12 +3130,11 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
-      "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz",
+      "integrity": "sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==",
       "requires": {
-        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/types": "5.15.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.10.1"
+    "@typescript-eslint/utils": "^5.15.0"
   },
   "devDependencies": {
     "@swc-node/register": "^1.4.2",
     "@swc/cli": "^0.1.55",
     "@swc/core": "^1.2.127",
     "@types/node": "^17.0.8",
-    "@typescript-eslint/eslint-plugin": "^5.10.0",
-    "@typescript-eslint/parser": "^5.10.0",
-    "@typescript-eslint/types": "^5.10.0",
+    "@typescript-eslint/eslint-plugin": "^5.15.0",
+    "@typescript-eslint/parser": "^5.15.0",
+    "@typescript-eslint/types": "^5.15.0",
     "eslint": "^8.0.1",
     "eslint-plugin-eslint-plugin": "^4.0.1",
     "eslint-plugin-unused-imports": "^2.0.0",

--- a/src/lib/getImportDeclaration.ts
+++ b/src/lib/getImportDeclaration.ts
@@ -1,13 +1,10 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
-import { ParserServices } from "@typescript-eslint/utils";
-import { ImportDeclaration } from "@typescript-eslint/types/dist/ast-spec";
+import { AST_NODE_TYPES, TSESTree, ParserServices } from "@typescript-eslint/utils";
 import { Symbol } from "typescript";
-import { JSXOpeningElement } from "@typescript-eslint/utils/node_modules/@typescript-eslint/types/dist/ast-spec";
 
 export function getImportDeclarationOfJSX(
-  node: JSXOpeningElement,
+  node: TSESTree.JSXOpeningElement,
   parserServices: ParserServices
-): ImportDeclaration | null {
+): TSESTree.ImportDeclaration | null {
   const typeChecker = parserServices.program.getTypeChecker();
   const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node.name);
   const symbol = typeChecker.getSymbolAtLocation(tsNode);
@@ -23,7 +20,7 @@ function getImportDeclarationOfSymbol(
   // eslint-disable-next-line @typescript-eslint/ban-types -- This Symbol is imported from "typescript"
   symbol: Symbol,
   parserServices: ParserServices
-): ImportDeclaration | null {
+): TSESTree.ImportDeclaration | null {
   if (symbol.declarations == null || symbol.declarations.length < 1) {
     return null;
   }

--- a/src/lib/isChakraElement.ts
+++ b/src/lib/isChakraElement.ts
@@ -1,14 +1,7 @@
-import { ParserServices } from "@typescript-eslint/utils";
-import { JSXOpeningElement } from "@typescript-eslint/types/dist/ast-spec";
-import {
-  Declaration,
-  ImportDeclaration,
-  Symbol,
-  SyntaxKind,
-  Expression,
-} from "typescript";
+import { TSESTree, ParserServices } from "@typescript-eslint/utils";
+import { Declaration, ImportDeclaration, Symbol, SyntaxKind, Expression } from "typescript";
 
-export function isChakraElement(node: JSXOpeningElement, parserServices: ParserServices): boolean {
+export function isChakraElement(node: TSESTree.JSXOpeningElement, parserServices: ParserServices): boolean {
   const typeChecker = parserServices.program.getTypeChecker();
   const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node.name);
   const symbol = typeChecker.getSymbolAtLocation(tsNode);

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -1,7 +1,6 @@
-import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { isChakraElement } from "../lib/isChakraElement";
 import { getPriority } from "../lib/getPriorityIndex";
-import { JSXAttribute, JSXSpreadAttribute } from "@typescript-eslint/types/dist/ast-spec";
 
 type Options = [
   {
@@ -107,11 +106,13 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
   },
 };
 
-const areAllJSXAttribute = (attributes: (JSXAttribute | JSXSpreadAttribute)[]): attributes is JSXAttribute[] => {
+const areAllJSXAttribute = (
+  attributes: (TSESTree.JSXAttribute | TSESTree.JSXSpreadAttribute)[]
+): attributes is TSESTree.JSXAttribute[] => {
   return attributes.every((attribute) => attribute.type === AST_NODE_TYPES.JSXAttribute);
 };
 
-const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[], config: Config) => {
+const sortAttributes = (unsorted: (TSESTree.JSXAttribute | TSESTree.JSXSpreadAttribute)[], config: Config) => {
   const noSpread = areAllJSXAttribute(unsorted);
 
   if (noSpread) {
@@ -123,13 +124,13 @@ const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[], config:
   // Sort sections which has only JSXAttributes.
   let start = 0;
   let end = 0;
-  let sorted: (JSXAttribute | JSXSpreadAttribute)[] = [];
+  let sorted: (TSESTree.JSXAttribute | TSESTree.JSXSpreadAttribute)[] = [];
   for (let i = 0; i < unsorted.length; i++) {
     if (unsorted[i].type === AST_NODE_TYPES.JSXSpreadAttribute) {
       end = i;
       if (start < end) {
         // Sort sections which don't have JSXSpreadAttribute.
-        const sectionToSort = unsorted.slice(start, end) as JSXAttribute[];
+        const sectionToSort = unsorted.slice(start, end) as TSESTree.JSXAttribute[];
         const sectionSorted = sectionToSort.sort((a, b) => compare(a, b, config));
         sorted = sorted.concat(sectionSorted);
       }
@@ -141,7 +142,7 @@ const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[], config:
       // This is last attribute and not spread one.
       end = i + 1;
       if (start < end) {
-        const sectionToSort = unsorted.slice(start, end) as JSXAttribute[];
+        const sectionToSort = unsorted.slice(start, end) as TSESTree.JSXAttribute[];
         const sectionSorted = sectionToSort.sort((a, b) => compare(a, b, config));
         sorted = sorted.concat(sectionSorted);
       }
@@ -150,7 +151,7 @@ const sortAttributes = (unsorted: (JSXAttribute | JSXSpreadAttribute)[], config:
   return sorted;
 };
 
-const compare = (a: JSXAttribute, b: JSXAttribute, config: Config) => {
+const compare = (a: TSESTree.JSXAttribute, b: TSESTree.JSXAttribute, config: Config) => {
   const aPriority = getPriority(a.name.name.toString(), config);
   const bPriority = getPriority(b.name.name.toString(), config);
 
@@ -168,8 +169,8 @@ const compare = (a: JSXAttribute, b: JSXAttribute, config: Config) => {
 };
 
 const createFix = (
-  unsotedAttribute: JSXAttribute | JSXSpreadAttribute,
-  sortedAttribute: JSXAttribute | JSXSpreadAttribute,
+  unsotedAttribute: TSESTree.JSXAttribute | TSESTree.JSXSpreadAttribute,
+  sortedAttribute: TSESTree.JSXAttribute | TSESTree.JSXSpreadAttribute,
   fixer: TSESLint.RuleFixer,
   sourceCode: Readonly<TSESLint.SourceCode>
 ) => {

--- a/src/rules/props-shorthand.ts
+++ b/src/rules/props-shorthand.ts
@@ -1,7 +1,6 @@
-import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { isChakraElement } from "../lib/isChakraElement";
 import { getNonShorthand, getShorthand } from "../lib/getShorthand";
-import { JSXAttribute } from "@typescript-eslint/types/dist/ast-spec";
 
 type Options = {
   noShorthand: boolean;
@@ -80,7 +79,11 @@ export const propsShorthandRule: TSESLint.RuleModule<"enforcesShorthand" | "enfo
     },
   };
 
-function getAttributeText(attribute: JSXAttribute, key: string, sourceCode: Readonly<TSESLint.SourceCode>): string {
+function getAttributeText(
+  attribute: TSESTree.JSXAttribute,
+  key: string,
+  sourceCode: Readonly<TSESLint.SourceCode>
+): string {
   if (attribute.value) {
     const valueText = sourceCode.getText(attribute.value);
     return `${key}=${valueText}`;

--- a/src/rules/require-specific-component.ts
+++ b/src/rules/require-specific-component.ts
@@ -1,12 +1,5 @@
-import { AST_NODE_TYPES, TSESLint } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESLint, TSESTree, ParserServices } from "@typescript-eslint/utils";
 import { isChakraElement } from "../lib/isChakraElement";
-import { ParserServices } from "@typescript-eslint/utils";
-import {
-  JSXAttribute,
-  JSXElement,
-  JSXOpeningElement,
-} from "@typescript-eslint/utils/node_modules/@typescript-eslint/types/dist/ast-spec";
-import { RuleFix } from "@typescript-eslint/utils/dist/ts-eslint";
 import { getImportDeclarationOfJSX } from "../lib/getImportDeclaration";
 import { findSpecificComponent } from "../lib/findSpecificComponent";
 
@@ -73,7 +66,7 @@ export const requireSpecificComponentRule: TSESLint.RuleModule<"requireSpecificC
                 createFixToRenameEndTag(node, specificComponent, fixer),
                 createFixToRemoveAttribute(attribute, node, fixer),
                 createFixToInsertImport(node, specificComponent, parserServices, fixer),
-              ].filter((v) => !!v) as RuleFix[];
+              ].filter((v) => !!v) as TSESLint.RuleFix[];
             },
           });
         }
@@ -82,12 +75,20 @@ export const requireSpecificComponentRule: TSESLint.RuleModule<"requireSpecificC
   },
 };
 
-function createFixToRenameEndTag(jsxNode: JSXOpeningElement, validComponent: string, fixer: TSESLint.RuleFixer) {
-  const endNode = (jsxNode.parent as JSXElement)?.closingElement;
+function createFixToRenameEndTag(
+  jsxNode: TSESTree.JSXOpeningElement,
+  validComponent: string,
+  fixer: TSESLint.RuleFixer
+) {
+  const endNode = (jsxNode.parent as TSESTree.JSXElement)?.closingElement;
   return endNode ? fixer.replaceText(endNode.name, validComponent) : null;
 }
 
-function createFixToRemoveAttribute(attribute: JSXAttribute, jsxNode: JSXOpeningElement, fixer: TSESLint.RuleFixer) {
+function createFixToRemoveAttribute(
+  attribute: TSESTree.JSXAttribute,
+  jsxNode: TSESTree.JSXOpeningElement,
+  fixer: TSESLint.RuleFixer
+) {
   const attributeIndex = jsxNode.attributes.findIndex((a) => a === attribute);
 
   if (attributeIndex === jsxNode.attributes.length - 1) {
@@ -101,7 +102,7 @@ function createFixToRemoveAttribute(attribute: JSXAttribute, jsxNode: JSXOpening
 }
 
 function createFixToInsertImport(
-  jsxNode: JSXOpeningElement,
+  jsxNode: TSESTree.JSXOpeningElement,
   validComponent: string,
   parserServices: ParserServices,
   fixer: TSESLint.RuleFixer


### PR DESCRIPTION
The version of `@typescript-eslint/typescript-estree` is fixed at `5.10.0` which depends on `dependencies > @typescript-eslint/utils`.

Our project is using TypeScript 4.6, but when we run eslint we get a warning about unsupported TypeScript.

```
$ eslint .
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.6.0

YOUR TYPESCRIPT VERSION: 4.6.2

Please only submit bug reports when using the officially supported version.

=============
```

I have upgraded the version of `@typescript-eslint/*` monorepo to solve this.